### PR TITLE
FIX error with android permissions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,11 +33,11 @@
   <platform name="android">
       <config-file target="res/xml/config.xml" parent="/*">
           <feature name="CallNumber">
-              <uses-permission android:name="android.permission.CALL_PHONE"/>
               <param name="android-package" value="com.oneserve.callnumber.CFCallNumber"/>
           </feature>
       </config-file>
       <config-file target="AndroidManifest.xml" parent="/manifest">
+          <uses-permission android:name="android.permission.CALL_PHONE"/>
           <uses-feature android:name="android.hardware.telephony" android:required="false" />
       </config-file>
       <source-file src="src/android/CFCallNumber.java" target-dir="src/com/oneserve/callnumber" />


### PR DESCRIPTION
Android Studio shows the error:  Namespace 'android' is not bound.
The right place for uses-permission is the AndroidManifest.xml file